### PR TITLE
Added the active contributor count link to Baloo data

### DIFF
--- a/css/dashboard.css
+++ b/css/dashboard.css
@@ -41,7 +41,7 @@ body {
     left: 0;
     z-index: 1000;
     display: block;
-    padding: 20px;
+    padding: 0px 20px 20px 20px;
     overflow-x: hidden;
     overflow-y: auto; /* Scrollable contents if viewport is shorter than content. */
     background-color: #f5f5f5;

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
             <li><a href="#" class="nav-link" data-src="https://dataviz.mozilla.org/views/moztrap/Results#1">Moztrap Results Dashboard</a></li>
             <li><a href="#" class="nav-link" data-src="http://mozmill-release.blargon7.com/">Mozmill Release Tests</a></li>
             <li><a href="#" class="nav-link" data-src="http://mozmill-daily.blargon7.com/">Mozmill Daily Builds</a></li>
+            <li><a href="#" class="nav-link" data-src="https://dataviz.mozilla.org/views/Active_Contributor_Dashboard/ByTeam#1">Active Contributor Count (LDAP)</a></li>
           </ul>
         </div>
         <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">

--- a/index.html
+++ b/index.html
@@ -22,6 +22,8 @@
             <li><a href="#" class="nav-link" data-src="http://mozilla-b2g.github.io/b2g-dashboard/">B2G Dashboard</a></li>
             <li><a href="#" class="nav-link" data-src="http://charts.mozilla.org/">charts.mozilla.org</a></li>
             <li><a href="#" class="nav-link" data-src="https://dataviz.mozilla.org/views/moztrap/Results#1">Moztrap Results Dashboard</a></li>
+            <li><a href="#" class="nav-link" data-src="http://mozmill-release.blargon7.com/">Mozmill Release Tests</a></li>
+            <li><a href="#" class="nav-link" data-src="http://mozmill-daily.blargon7.com/">Mozmill Daily Builds</a></li>
           </ul>
         </div>
         <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2 main">

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
       <div class="row">
         <div class="col-sm-3 col-md-2 sidebar">
           <ul class="nav nav-sidebar">
-            <li class="active"><a href="#" class="nav-link" data-src="http://mozilla.github.io/mozwebqa-dashboard">MozWebQA Dashboard</a></li>
+            <li><a href="#" class="nav-link" data-src="http://mozilla.github.io/mozwebqa-dashboard">MozWebQA Dashboard</a></li>
             <li><a href="#" class="nav-link" data-src="https://crash-analysis.mozilla.com/rkaiser/crash-report-tools/qa/">Firefox QA Dashboard</a></li>
             <li><a href="#" class="nav-link" data-src="http://mozilla-b2g.github.io/b2g-dashboard/">B2G Dashboard</a></li>
             <li><a href="#" class="nav-link" data-src="http://charts.mozilla.org/">charts.mozilla.org</a></li>

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -8,4 +8,9 @@ $(function() {
     $("#content-iframe").attr('src', $(this).attr('data-src'));
   });
 
+  $("ul.nav li").click(function () {
+    $("ul.nav li").removeClass('active');
+    $(this).addClass('active');
+  });
+
 });

--- a/welcome.html
+++ b/welcome.html
@@ -1,10 +1,14 @@
 <!DOCTYPE html>
 <html>
-<head lang="en">
-  <meta charset="UTF-8">
-  <title></title>
-</head>
-<body>
-Choose a dashboard from the list on the left
-</body>
+  <head lang="en">
+    <meta charset="UTF-8">
+    <link href="css/bootstrap.min.css" rel="stylesheet">
+    <title>QA Dashboard of Dashboards</title>
+  </head>
+  <body>
+    <div class="container">
+        <h1>QA Dashboard of Dashboards</h1>
+        <p>Choose a dashboard from the list on the left</p>
+    </div>
+  </body>
 </html>


### PR DESCRIPTION
Marc asked me to add this but note that it is visible only if people have LDAP access. It is also not possible as far as I could tell to permalink to only QA data. It is clear enough to click on it from the main view, though. 
